### PR TITLE
Use `CGI.build_form` instead of manually creating the query string

### DIFF
--- a/src/ezoe.cr
+++ b/src/ezoe.cr
@@ -27,11 +27,11 @@ def post_question(user, question)
   token = response.body.match(/<input name="authenticity_token" type="hidden" value="([^"]+)"/).try &.[1]
   error "authentication token not found" unless token
 
-  params = [
-              "authenticity_token", token,
-              "question[question_text]", question,
-              "question[force_anonymous]", "force_anonymous",
-           ].map{|p| CGI.escape p}.each_slice(2).map{|kv| "#{kv[0]}=#{kv[1]}"}.join('&')
+  params = CGI.build_form do |form|
+    form.add "authenticity_token", token
+    form.add "question[question_text]", question
+    form.add "question[force_anonymous]", "force_anonymous",
+  end
 
   response = HTTP::Client.post(
       "http://ask.fm/#{user}/questions/create?#{params}",


### PR DESCRIPTION
Hi @rhysd!

This is just because the code is very short and I'd like it to be shorter, and also to let you know that there's `CGI.build_form` (although it's not documented well yet).

I didn't test it because I don't know what's `ezoe` (and my Japanese is very bad, すみません), but it compiles :-)
